### PR TITLE
Make capture_warnings thread-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,14 @@ You can report them to your exception tracker:
 or totally silence them:
 
 ```ruby
-  PedantMysql2.on_warning = lambda { |*| }
+  PedantMysql2.silence_warnings!
 ```
 
-Or whatever else behaviour you want (logging).
+and to restore it to raising warnings as errors:
+
+```ruby
+  PedantMysql2.raise_warnings!
+```
 
 You can easilly whitelist some types of warnings:
 
@@ -58,6 +62,14 @@ warnings = PedantMysql2.capture_warnings do
   # perform query that may raise an error you want to stifle
 end
  ```
+
+## Thread-safe
+
+This gem is tested to be thread safe with one known exception.
+
+`PedantMysql2.ignore` is not thread safe and should only be called during intialization of your app. Changing this within a thread while another is updating it could be problematic.
+
+If you find any other parts that are not thread-safe, please create an issue or PR.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ end
 
 ## Thread-safe
 
-This gem is tested to be thread safe with one known exception.
+This gem is tested to be thread safe with a couple known exceptions.
 
-`PedantMysql2.ignore` is not thread safe and should only be called during intialization of your app. Changing this within a thread while another is updating it could be problematic.
+`PedantMysql2.ignore` is not thread safe and should only be called during initialization of your app. Changing this within a thread while another is updating it could be problematic.
+`PedantMysql2.on_warning=` is not thread safe, this should also be called only during initialization.
 
 If you find any other parts that are not thread-safe, please create an issue or PR.
 

--- a/lib/active_record/connection_adapters/pedant_mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/pedant_mysql2_adapter.rb
@@ -63,7 +63,7 @@ class ActiveRecord::ConnectionAdapters::PedantMysql2Adapter < ActiveRecord::Conn
     result = @connection.query('SHOW WARNINGS')
     result.each do |level, code, message|
       warning = MysqlWarning.new(message, code, level, sql)
-      ::PedantMysql2.on_warning.call(warning) unless PedantMysql2.ignored?(warning)
+      ::PedantMysql2.warn(warning)
     end
   end
 end

--- a/lib/pedant_mysql2.rb
+++ b/lib/pedant_mysql2.rb
@@ -32,11 +32,11 @@ module PedantMysql2
     end
 
     def on_warning
-      Thread.current[:__pedant_mysql2_on_warning]
+      Thread.current[:__pedant_mysql2_on_warning] || @_on_warning
     end
 
     def on_warning=(new_proc)
-      Thread.current[:__pedant_mysql2_on_warning] = new_proc
+      @_on_warning = new_proc
     end
 
     protected
@@ -51,7 +51,7 @@ module PedantMysql2
 
     def setup_capture
       Thread.current[:__pedant_mysql2_warnings] = []
-      self.on_warning = lambda { |warning| Thread.current[:__pedant_mysql2_warnings] << warning }
+      self.thread_on_warning = lambda { |warning| Thread.current[:__pedant_mysql2_warnings] << warning }
     end
 
     def captured_warnings
@@ -59,11 +59,15 @@ module PedantMysql2
     end
 
     def backup_warnings
-      [captured_warnings, on_warning]
+      [captured_warnings, Thread.current[:__pedant_mysql2_on_warning]]
     end
 
     def restore_warnings(warnings)
-      Thread.current[:__pedant_mysql2_warnings], self.on_warning = *warnings
+      Thread.current[:__pedant_mysql2_warnings], self.thread_on_warning = *warnings
+    end
+
+    def thread_on_warning=(new_proc)
+      Thread.current[:__pedant_mysql2_on_warning] = new_proc
     end
   end
 end

--- a/lib/pedant_mysql2.rb
+++ b/lib/pedant_mysql2.rb
@@ -1,34 +1,42 @@
 module PedantMysql2
   class << self
-    attr_accessor :on_warning
-
     def capture_warnings
-      previous_callback = on_warning
-      previous_warnings = Thread.current[:mysql_warnings]
-      Thread.current[:mysql_warnings] = []
-      self.on_warning = lambda { |warning| Thread.current[:mysql_warnings] << warning }
+      warnings = backup_warnings
+      setup_capture
       yield
-      warnings = Thread.current[:mysql_warnings]
-      warnings
+      captured_warnings
     ensure
-      Thread.current[:mysql_warnings] = previous_warnings
-      self.on_warning = previous_callback
+      restore_warnings(warnings)
     end
 
     def raise_warnings!
-      self.on_warning = lambda{ |warning| raise warning }
+      self.on_warning = nil
     end
 
     def silence_warnings!
-      self.on_warning = nil
+      self.on_warning = lambda{ |warning| }
     end
 
     def ignore(*matchers)
       self.whitelist.concat(matchers.flatten)
     end
 
-    def ignored?(warning)
-      on_warning.nil? || whitelist.any? { |matcher| matcher =~ warning.message }
+    def warn(warning)
+      return if ignored?(warning)
+
+      if on_warning
+        on_warning.call(warning)
+      else
+        raise warning
+      end
+    end
+
+    def on_warning
+      Thread.current[:__pedant_mysql2_on_warning]
+    end
+
+    def on_warning=(new_proc)
+      Thread.current[:__pedant_mysql2_on_warning] = new_proc
     end
 
     protected
@@ -37,8 +45,25 @@ module PedantMysql2
       @whitelist ||= []
     end
 
+    def ignored?(warning)
+      whitelist.any? { |matcher| matcher =~ warning.message }
+    end
+
+    def setup_capture
+      Thread.current[:__pedant_mysql2_warnings] = []
+      self.on_warning = lambda { |warning| Thread.current[:__pedant_mysql2_warnings] << warning }
+    end
+
+    def captured_warnings
+      Thread.current[:__pedant_mysql2_warnings]
+    end
+
+    def backup_warnings
+      [captured_warnings, on_warning]
+    end
+
+    def restore_warnings(warnings)
+      Thread.current[:__pedant_mysql2_warnings], self.on_warning = *warnings
+    end
   end
-
-  raise_warnings!
-
 end

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -125,6 +125,17 @@ describe PedantMysql2 do
     thread.join
   end
 
+  it 'should inherit on_warning from parent thread' do
+    PedantMysql2.silence_warnings!
+    thread = Thread.new do
+      expect {
+        execute_with_warning
+      }.to_not raise_error
+    end
+
+    thread.join
+  end
+
   describe MysqlWarning do
 
     subject do

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -5,6 +5,7 @@ ActiveRecord::Base.configurations = {
     username: 'travis',
     encoding: 'utf8',
     strict: false,
+    pool: 5,
   },
 }
 ActiveRecord::Base.establish_connection(:test)


### PR DESCRIPTION
Fixed capture_warnings to be thread-safe. To reliably test the race condition I broke up the capture_warnings method so it could be called in pieces from the test. Made the new methods protected but I bypass this in the tests with a method_missing.

To find the race condition in the first place I used this test. But due to it not being 100% consistent I didn't want to include it in the specs.
```ruby
require 'spec_helper'

describe "Test PedantMysql2 for thread-safetyness through brute force" do
  it 'should be thread-safe to capture_warnings' do
    tests = [Proc.new do
      warnings = PedantMysql2.capture_warnings do
        ActiveRecord::Base.connection.execute('SELECT 1 + "foo"')
      end
      expect(warnings.size).to be == 1
    end,
    Proc.new do
      warnings = PedantMysql2.capture_warnings do
        ActiveRecord::Base.connection.execute('SELECT 1 + 1')
      end
      expect(warnings.size).to be == 0
    end]

    [0,0,0,0].map do
      Thread.start do
        1000.times do
          tests[rand(2)].call
        end
      end
    end.each(&:join)
  end
end
```

Rewrote the spec testing warnings being restored to be a bit more practical.  Also did some refactoring of the tests to remove a bit of duplication.

@wvanbergen @byroot 
cc: @disaacs thought you might find this interesting