### PR TITLE
Don't skip original exec_delete (fixes Marginalia for UPDATE and DELETE)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+  - 2.2.0
+  - 2.3.0
 
 gemfile:
   - Gemfile.activerecord32
   - Gemfile.activerecord40
   - Gemfile.activerecord41
   - Gemfile.activerecord42
+  - Gemfile.activerecord50
 
 before_script:
   - mysql -e 'create database pedant_mysql2_test;'

--- a/Gemfile.activerecord50
+++ b/Gemfile.activerecord50
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec
+
+gem 'activerecord', '~> 5.0.0'

--- a/lib/active_record/connection_adapters/pedant_mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/pedant_mysql2_adapter.rb
@@ -37,8 +37,7 @@ class MysqlWarning < StandardError
 end
 
 class ActiveRecord::ConnectionAdapters::PedantMysql2Adapter < ActiveRecord::ConnectionAdapters::Mysql2Adapter
-
-  alias_method :original_execute, :execute
+  alias_method :exec_delete_without_pedant, :exec_delete
 
   def execute(sql, name = nil)
     value = super
@@ -47,7 +46,7 @@ class ActiveRecord::ConnectionAdapters::PedantMysql2Adapter < ActiveRecord::Conn
   end
 
   def exec_delete(sql, name, binds)
-    original_execute to_sql(sql, binds), name
+    exec_delete_without_pedant(to_sql(sql, binds), name, binds)
     affected_rows = @connection.affected_rows
     log_warnings(sql)
     affected_rows


### PR DESCRIPTION
Overwriting `exec_delete` in this way breaks [marginalia](https://github.com/basecamp/marginalia) instrumentation if used in combination with this gem.

This PR fixes that by calling the superclass method instead of the `execute` method. This works because Marginalia [overwrites](https://github.com/basecamp/marginalia/blob/25c1af617bc8505d78cba38c17712c3ff86307b0/lib/marginalia.rb#L66-L72) that method.

@casperisfine @kirs 

Some test runs on Travis are failing because some newer version of some non-locked gem wants a newer Ruby version than what we are testing with :-(