### PR TITLE
UPDATE/DELETE: Lets try that again

### DIFF
--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -55,13 +55,27 @@ describe PedantMysql2 do
     expect(result.to_a).to be == [[1.0]]
   end
 
-  it 'do not change the returned value of exec_update' do
+  it 'does not change the returned value of exec_update' do
+    connection.execute('INSERT INTO comment VALUES (17)')
     result = connection.update('UPDATE comment SET id = 1 ORDER BY id LIMIT 1')
+    expect(result).to be == 1
+  end
+
+  it 'does not change the returned value of exec_update when there is warnings' do
+    PedantMysql2.silence_warnings!
+    result = connection.update('UPDATE comment SET id = 1 WHERE id > (42+"foo") ORDER BY id LIMIT 1')
     expect(result).to be_zero
   end
 
-  it 'do not change the returned value of exec_delete' do
+  it 'does not change the returned value of exec_delete' do
+    connection.execute('INSERT INTO comment VALUES (17)')
     result = connection.delete('DELETE FROM comment ORDER BY id LIMIT 1')
+    expect(result).to be == 1
+  end
+
+  it 'does not change the returned value of exec_delete when there is warnings' do
+    PedantMysql2.silence_warnings!
+    result = connection.delete('DELETE FROM comment WHERE id > (42+"foo") ORDER BY id LIMIT 1')
     expect(result).to be_zero
   end
 


### PR DESCRIPTION
Second try at fixing https://github.com/Shopify/activerecord-pedantmysql2-adapter/pull/10.

This is why the first attempt had a bug:
* Call `exec_delete`
* Which calls `exec_delete_without_pedant`
* Which calls `exec_query`
* Which calls `execute` (the one we already patched!)
* Which calls `log_warnings`
* Which now sometimes calls `@connection.query("SHOW WARNINGS")`
* Now back in `exec_delete`, we call `@connection.affected_rows`. This is fine in most cases (it returns the number of rows that were deleted). But in case the connection had warnings, this now returns the number of warnings (because `affected_rows`, referring to the most recent query, now refers to the `SHOW WARNINGS` query, not to the `DELETE`).

This PR gets around that by remembering the number of affected rows before making the logging query.

This still feels pretty shitty... I guess that is what happens when two gems (this one and marginalia) both try to overwrite the same activerecord internal method :-(

Thoughts?

@rafaelfranca @casperisfine @bslobodin @daniellaniyo