### PR TITLE
Do not raise exception if Mysql warns about unexisting table when dropping it:

### DIFF
--- a/lib/pedant_mysql2.rb
+++ b/lib/pedant_mysql2.rb
@@ -46,7 +46,11 @@ module PedantMysql2
     end
 
     def ignored?(warning)
-      whitelist.any? { |matcher| matcher =~ warning.message }
+      whitelist.any? { |matcher| matcher =~ warning.message } || drop_table_warning(warning)
+    end
+
+    def drop_table_warning(warning)
+      warning.query =~ /\ADROP TABLE IF EXISTS/ || warning.message =~ /\AUnknown table/
     end
 
     def setup_capture

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -19,8 +19,8 @@ describe PedantMysql2 do
     PedantMysql2.on_warning = @original_callback
   end
 
-  def execute_with_warning
-    ActiveRecord::Base.connection.execute('SELECT 1 + "foo"')
+  def execute_with_warning(query = 'SELECT 1 + "foo"')
+    ActiveRecord::Base.connection.execute(query)
   end
 
   def wait_for(thread)
@@ -40,6 +40,12 @@ describe PedantMysql2 do
     expect {
       execute_with_warning
     }.to raise_error(MysqlWarning, "Truncated incorrect DOUBLE value: 'foo'")
+  end
+
+  it 'does not raise when warning warns about unexisting table' do
+    expect {
+      execute_with_warning('DROP TABLE IF EXISTS `example_table`')
+    }.to_not raise_error
   end
 
   it 'can have a whitelist of warnings' do


### PR DESCRIPTION
Do not raise exception if Mysql warns about unexisting table when dropping it:

- When a SQL query like this gets executed `DROP TABLE IF EXISTS `no_such_table`', Mysql will output a simple warning
```
     mysql> DROP TABLE IF EXISTS test.no_such_table;
     Query OK, 0 rows affected, 1 warning (0.00 sec)
     mysql> SHOW WARNINGS;
     +-------+------+------------------------------------+
     | Level | Code | Message                            |
     +-------+------+------------------------------------+
     | Note  | 1051 | Unknown table 'test.no_such_table' |
     +-------+------+------------------------------------+
     1 row in set (0.00 sec)
  ```
- pedant_mysql adapter should not raise an exception on this warning

cc/ @rafaelfranca @lugray 