### PR TITLE
Release 1.4.0

### DIFF
--- a/lib/pedant_mysql2/version.rb
+++ b/lib/pedant_mysql2/version.rb
@@ -1,3 +1,3 @@
 module PedantMysql2
-  VERSION = '1.3.1'
+  VERSION = '1.4.0'
 end


### PR DESCRIPTION
Contains 1 PR: https://github.com/Shopify/activerecord-pedantmysql2-adapter/pull/24

Minor version bump was suggested by @adrianna-chang-shopify for this version.