### PR TITLE
Add deprecation warning for Rails 7.1

### DIFF
--- a/lib/activerecord-pedantmysql2-adapter.rb
+++ b/lib/activerecord-pedantmysql2-adapter.rb
@@ -1,4 +1,8 @@
 require 'active_record'
+if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+  ActiveSupport::Deprecation.warn("activerecord-pedantmysql2-adapter was integrated into Rails 7.1, so is deprecated"
+end
+
 require 'pedant_mysql2'
 require 'pedant_mysql2/version'
 require 'active_record/connection_adapters/pedant_mysql2_adapter'


### PR DESCRIPTION
The README already has this message:

> This gem is deprecated as of Active Record 7.1, and will be archived once a subsequent version of Active Record is released.

This will hopefully help make sure it's visible to users of the gem when it's used.